### PR TITLE
Add response_length arg to failure event

### DIFF
--- a/realbrowserlocusts/core.py
+++ b/realbrowserlocusts/core.py
@@ -25,6 +25,7 @@ def wrap_for_locust(request_type, name, func, *args, **kwargs):
             request_type=request_type,
             name=name,
             response_time=total_time,
+            response_length=0,
             exception=event_exception
         )
         raise StopLocust()


### PR DESCRIPTION
This is a recent response to a [recent change in Locust](https://github.com/locustio/locust/commit/7bc9292cb7d67be0e891a3eb3f7bb2e4e89beb91) that adds the response_length keyword argument.